### PR TITLE
Remove validator library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 composer.lock
 .idea
+.phpunit.result.cache
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.2] - 2020-01-08
+
+### Changed
+- Plugin version is now a mandatory parameter and needs to be passed via Client constructor.
+- All validation is done now via filter_var() and empty() to prevent problems with certain hosting providers that don't have MBString enabled.
+
+### Added
+- PHPUnit suite and tests
+
+### Removed
+- Removed validation library.
+
+

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,8 @@
         "psr-4": {
             "OpMerchantServices\\SDK\\": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3.3",
-        "respect/validation": "^1.1.29",
         "ext-json": "*"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpunit bootstrap="vendor/autoload.php"
+        colors="true"
+        stopOnFailure="false">
+    <testsuites>
+        <testsuite name="OP-SDK testsuite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -106,6 +106,25 @@ class Client
     protected $cofPluginVersion;
 
     /**
+     * @param string $cofPluginVersion
+     * @return Client
+     */
+    public function setCofPluginVersion(string $cofPluginVersion): Client
+    {
+        $this->cofPluginVersion = $cofPluginVersion;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCofPluginVersion(): string
+    {
+        return $this->cofPluginVersion;
+    }
+
+
+    /**
      * The Guzzle HTTP client.
      *
      * @var \GuzzleHttp\Client
@@ -122,6 +141,7 @@ class Client
      *
      * @param int    $merchantId The merchant.
      * @param string $secretKey  The secret key.
+     * @param string $cofPluginVersion Plugin version.
      * @param array $args {
      *      Optional. Array of additional arguments.
      *
@@ -131,10 +151,11 @@ class Client
      *      @type string          $message_format   The format for logger messages.
      *                                              See: https://github.com/guzzle/guzzle/blob/master/src/MessageFormatter.php#L9
      */
-    public function __construct(int $merchantId, string $secretKey, $args = [])
+    public function __construct(int $merchantId, string $secretKey, string $cofPluginVersion, $args = [])
     {
         $this->setMerchantId($merchantId);
         $this->setSecretKey($secretKey);
+        $this->setCofPluginVersion($cofPluginVersion);
 
         $stack = $this->createLoggerStack($args);
 
@@ -146,8 +167,6 @@ class Client
                 'handler'  => $stack,
             ]
         );
-
-        $this->cofPluginVersion = $args['cofPluginVersion'] ?? 'php-sdk-default';
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -182,6 +182,7 @@ class Client
      *                               not required for a new payment request.
      *
      * @return array
+     * @throws \Exception
      */
     protected function getHeaders(string $method, string $transactionId = null)
     {

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -5,8 +5,6 @@
 
 namespace OpMerchantServices\SDK\Exception;
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Throwable;
 
 /**
  * Class ValidationException

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -5,8 +5,7 @@
 
 namespace OpMerchantServices\SDK\Model;
 
-use Respect\Validation\Validator as v;
-use Respect\Validation\Exceptions\NestedValidationException;
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Util\JsonSerializable;
 
 /**
@@ -25,17 +24,29 @@ class Address implements \JsonSerializable
     /**
      * Validates with Respect\Validation library and throws exception for invalid objects
      *
-     * @throws NestedValidationException Thrown when the assert() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
         $props = get_object_vars($this);
 
-        v::key('streetAddress', v::notEmpty())
-        ->key('postalCode', v::notEmpty())
-        ->key('city', v::notEmpty())
-        ->key('country', v::notEmpty())
-        ->assert($props);
+        if (empty($props['streetAddress'])) {
+            throw new ValidationException('streetAddress is empty');
+        }
+
+        if (empty($props['postalCode'])) {
+            throw new ValidationException('postalCode is empty');
+        }
+
+        if (empty($props['city'])) {
+            throw new ValidationException('city is empty');
+        }
+
+        if (empty($props['country'])) {
+            throw new ValidationException('country is empty');
+        }
+
+        return true;
     }
 
     /**

--- a/src/Model/CallbackUrl.php
+++ b/src/Model/CallbackUrl.php
@@ -5,9 +5,8 @@
 
 namespace OpMerchantServices\SDK\Model;
 
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Util\JsonSerializable;
-use Respect\Validation\Validator as v;
-use Respect\Validation\Exceptions\NestedValidationException;
 
 /**
  * Class CallbackUrl
@@ -25,15 +24,21 @@ class CallbackUrl implements \JsonSerializable
     /**
      * Validates with Respect\Validation library and throws an exception for invalid objects
      *
-     * @throws NestedValidationException Thrown when the assert() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
         $props = get_object_vars($this);
 
-        v::key('success', v::notEmpty())
-        ->key('cancel', v::notEmpty())
-        ->assert($props);
+        if (empty($props['success'])) {
+            throw new ValidationException('Success is empty');
+        }
+
+        if (empty($props['cancel'])) {
+            throw new ValidationException('Cancel is empty');
+        }
+
+        return true;
     }
 
     /**

--- a/src/Model/CallbackUrl.php
+++ b/src/Model/CallbackUrl.php
@@ -38,6 +38,14 @@ class CallbackUrl implements \JsonSerializable
             throw new ValidationException('Cancel is empty');
         }
 
+        if (!filter_var($props['success'], FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED)) {
+            throw new ValidationException('Success is not a valid URL');
+        }
+
+        if (!filter_var($props['cancel'], FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED)) {
+            throw new ValidationException('Cancel is not a valid URL');
+        }
+
         return true;
     }
 

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -34,7 +34,7 @@ class Customer implements \JsonSerializable
             throw new ValidationException('Email is empty');
         }
 
-        if (filter_var($props['email'], FILTER_VALIDATE_EMAIL)) {
+        if (!filter_var($props['email'], FILTER_VALIDATE_EMAIL)) {
             throw new ValidationException('Email is not a valid email address');
         }
 

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -5,8 +5,7 @@
 
 namespace OpMerchantServices\SDK\Model;
 
-use Respect\Validation\Validator as v;
-use Respect\Validation\Exceptions\NestedValidationException;
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Util\JsonSerializable;
 
 /**
@@ -23,16 +22,23 @@ class Customer implements \JsonSerializable
     use JsonSerializable;
 
     /**
-     * Validates with Respect\Validation library and throws an exception for invalid objects
+     * Validate email
      *
-     * @throws NestedValidationException Thrown when the assert() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
         $props = get_object_vars($this);
 
-        v::key('email', v::notEmpty()->email())
-        ->assert($props);
+        if (empty($props['email'])) {
+            throw new ValidationException('Email is empty');
+        }
+
+        if (filter_var($props['email'], FILTER_VALIDATE_EMAIL)) {
+            throw new ValidationException('Email is not a valid email address');
+        }
+
+        return true;
     }
 
     /**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Class Item
+ * Class ItemTest
  */
 
 namespace OpMerchantServices\SDK\Model;
 
-use Respect\Validation\Validator as v;
-use Respect\Validation\Exceptions\NestedValidationException;
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Util\JsonSerializable;
+use MongoLog;
 
 /**
- * Class Item
+ * Class ItemTest
  *
  * This class defines payment item details.
  *
@@ -19,26 +19,7 @@ use OpMerchantServices\SDK\Util\JsonSerializable;
  */
 class Item implements \JsonSerializable
 {
-
     use JsonSerializable;
-
-    /**
-     * Validates with Respect\Validation library and throws an exception for invalid objects
-     *
-     * @throws NestedValidationException Thrown when the assert() fails.
-     */
-    public function validate()
-    {
-        $props = get_object_vars($this);
-
-        v::key('unitPrice', v::intType())
-        ->key('units', v::intType())
-        ->key('vatPercentage', v::intType())
-        ->key('productCode', v::notEmpty())
-        ->key('deliveryDate', v::notEmpty())
-        ->key('description', v::stringType()->length(null,1000))
-        ->assert($props);
-    }
 
     /**
      * Price per unit, VAT included, in each country's
@@ -375,5 +356,35 @@ class Item implements \JsonSerializable
         $this->commission = $commission;
 
         return $this;
+    }
+
+
+    /**
+     * Validates with Respect\Validation library and throws an exception for invalid objects
+     *
+     * @throws ValidationException
+     */
+    public function validate()
+    {
+        $props = get_object_vars($this);
+
+        if (!filter_var($props['unitPrice'], FILTER_VALIDATE_INT)) {
+            //throw new \Exception('UnitPrice is not an integer');
+            throw new ValidationException('UnitPrice is not an integer');
+        }
+        if (!filter_var($props['units'], FILTER_VALIDATE_INT)) {
+            throw new ValidationException('Units is not an integer');
+        }
+        if (!filter_var($props['vatPercentage'], FILTER_VALIDATE_INT)) {
+            throw new ValidationException('vatPercentage is not an integer');
+        }
+        if (empty($props['productCode'])) {
+            throw new ValidationException('productCode is empty');
+        }
+        if (empty($props['deliveryDate'])) {
+            throw new ValidationException('deliveryDate is empty');
+        }
+
+        return true;
     }
 }

--- a/src/Model/RefundItem.php
+++ b/src/Model/RefundItem.php
@@ -5,9 +5,8 @@
 
 namespace OpMerchantServices\SDK\Model;
 
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Util\JsonSerializable;
-use Respect\Validation\Validator as v;
-use Respect\Validation\Exceptions\NestedValidationException;
 
 /**
  * Class RefundItem
@@ -24,14 +23,21 @@ class RefundItem implements \JsonSerializable
     /**
      * Validates with Respect\Validation library and throws an exception for invalid objects
      *
-     * @throws NestedValidationException Thrown when the assert() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
         $props = get_object_vars($this);
 
-        v::key('amount', v::notEmpty()->intVal())
-         ->assert($props);
+        if (empty($props['amount'])) {
+            throw new ValidationException('Amount is empty');
+        }
+
+        if (filter_var($props['amount'], FILTER_VALIDATE_INT)) {
+            throw new ValidationException('Amount is empty');
+        }
+
+        return true;
     }
 
     /**

--- a/src/Model/RefundItem.php
+++ b/src/Model/RefundItem.php
@@ -33,8 +33,12 @@ class RefundItem implements \JsonSerializable
             throw new ValidationException('Amount is empty');
         }
 
-        if (filter_var($props['amount'], FILTER_VALIDATE_INT)) {
-            throw new ValidationException('Amount is empty');
+        if (empty($props['stamp'])) {
+            throw new ValidationException('Stamp can not be empty');
+        }
+
+        if (!is_string($props['stamp'])) {
+            throw new ValidationException('Stamp is not a string');
         }
 
         return true;

--- a/src/Request/EmailRefundRequest.php
+++ b/src/Request/EmailRefundRequest.php
@@ -5,6 +5,7 @@
 
 namespace OpMerchantServices\SDK\Request;
 
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Interfaces\RequestInterface;
 use OpMerchantServices\SDK\Model\CallbackUrl;
 use OpMerchantServices\SDK\Model\RefundItem;
@@ -33,12 +34,21 @@ class EmailRefundRequest extends RefundRequest
      * Validates with Respect\Validation library and throws an exception for invalid objects
      *
      * @throws NestedValidationException Thrown when the validate() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
         parent::validate();
 
-        v::notEmpty()->email()->validate($this->email);
+        if (empty($this->email)) {
+            throw new ValidationException('email can not be empty');
+        }
+
+        if (!filter_var($this->email, FILTER_VALIDATE_EMAIL)) {
+            throw new ValidationException('email is not a valid email address');
+        }
+
+        return true;
     }
 
     /**

--- a/src/Request/PaymentRequest.php
+++ b/src/Request/PaymentRequest.php
@@ -5,6 +5,7 @@
 
 namespace OpMerchantServices\SDK\Request;
 
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Interfaces\RequestInterface;
 use OpMerchantServices\SDK\Model\Address;
 use OpMerchantServices\SDK\Model\CallbackUrl;
@@ -29,13 +30,32 @@ class PaymentRequest implements \JsonSerializable, RequestInterface
     use JsonSerializable;
 
     /**
+     * @var array
+     */
+    private $supportedCurrencies = ['EUR'];
+
+    /**
+     * @var array
+     */
+    private $supportedLanguages = ['FI', 'SV', 'EN'];
+
+    /**
      * Validates with Respect\Validation library and throws an exception for invalid objects
      *
      * @throws NestedValidationException Thrown when the assert() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
         $props = get_object_vars($this);
+
+        if (empty($props['items'])) {
+            throw new ValidationException('Items is empty');
+        }
+
+        if (!is_array($props['items'])) {
+            throw new ValidationException('Items needs to be type of array');
+        }
 
         // Count the total amount of the payment.
         $items_total = array_reduce($this->getItems(), function ($carry = 0, ?Item $item = null) {
@@ -45,19 +65,45 @@ class PaymentRequest implements \JsonSerializable, RequestInterface
             return $item->getUnitPrice() * $item->getUnits() + $carry;
         });
 
-        v::key('stamp', v::notEmpty())
-        ->key('reference', v::notEmpty())
-        ->key('amount', v::notEmpty()->intVal()->equals($items_total))
-        ->key('currency', v::notEmpty()->equals('EUR'))
-        ->key('language', v::oneOf(
-            v::equals('FI'),
-            v::equals('SV'),
-            v::equals('EN')
-        ))
-        ->key('items', v::notEmpty()->arrayType())
-        ->key('customer', v::notEmpty())
-        ->key('redirectUrls', v::notEmpty())
-        ->assert($props);
+        if (empty($props['amount'])) {
+            throw new ValidationException('Amount is empty');
+        }
+
+        if (!filter_var($props['amount'], FILTER_VALIDATE_INT)) {
+            throw new ValidationException('Amount is not a number');
+        }
+
+        if ($props['amount'] !== $items_total) {
+            throw new ValidationException('Amount doesnt match ItemsTotal');
+        }
+
+        if (empty($props['stamp'])) {
+            throw new ValidationException('Stamp is empty');
+        }
+
+        if (empty($props['reference'])) {
+            throw new ValidationException('Reference is empty');
+        }
+
+        if (empty($props['currency'])) {
+            throw new ValidationException('Currency is empty');
+        }
+
+        if (!in_array($props['currency'], $this->supportedCurrencies)) {
+            throw new ValidationException('Unsupported currency chosen');
+        }
+
+        if (!in_array($props['language'], $this->supportedLanguages)) {
+            throw new ValidationException('Unsupported language chosen');
+        }
+
+        if (empty($props['customer'])) {
+            throw new ValidationException('Customer is empty');
+        }
+
+        if (empty($props['redirectUrls'])) {
+            throw new ValidationException('RedirectUrls is empty');
+        }
 
         // Validate the items.
         array_walk($this->items, function (Item $item) {
@@ -74,6 +120,8 @@ class PaymentRequest implements \JsonSerializable, RequestInterface
         if (! empty($this->invoicingAddress)) {
             $this->invoicingAddress->validate();
         }
+
+        return true;
     }
 
     /**

--- a/src/Request/PaymentRequest.php
+++ b/src/Request/PaymentRequest.php
@@ -30,16 +30,6 @@ class PaymentRequest implements \JsonSerializable, RequestInterface
     use JsonSerializable;
 
     /**
-     * @var array
-     */
-    private $supportedCurrencies = ['EUR'];
-
-    /**
-     * @var array
-     */
-    private $supportedLanguages = ['FI', 'SV', 'EN'];
-
-    /**
      * Validates with Respect\Validation library and throws an exception for invalid objects
      *
      * @throws NestedValidationException Thrown when the assert() fails.
@@ -48,6 +38,9 @@ class PaymentRequest implements \JsonSerializable, RequestInterface
     public function validate()
     {
         $props = get_object_vars($this);
+
+        $supportedLanguages = ['FI', 'SV', 'EN'];
+         $supportedCurrencies = ['EUR'];
 
         if (empty($props['items'])) {
             throw new ValidationException('Items is empty');
@@ -89,11 +82,11 @@ class PaymentRequest implements \JsonSerializable, RequestInterface
             throw new ValidationException('Currency is empty');
         }
 
-        if (!in_array($props['currency'], $this->supportedCurrencies)) {
+        if (!in_array($props['currency'], $supportedCurrencies)) {
             throw new ValidationException('Unsupported currency chosen');
         }
 
-        if (!in_array($props['language'], $this->supportedLanguages)) {
+        if (!in_array($props['language'], $supportedLanguages)) {
             throw new ValidationException('Unsupported language chosen');
         }
 

--- a/src/Request/RefundRequest.php
+++ b/src/Request/RefundRequest.php
@@ -5,6 +5,7 @@
 
 namespace OpMerchantServices\SDK\Request;
 
+use OpMerchantServices\SDK\Exception\ValidationException;
 use OpMerchantServices\SDK\Interfaces\RequestInterface;
 use OpMerchantServices\SDK\Model\CallbackUrl;
 use OpMerchantServices\SDK\Model\RefundItem;
@@ -28,6 +29,7 @@ class RefundRequest implements \JsonSerializable, RequestInterface
      * Validates with Respect\Validation library and throws an exception for invalid objects
      *
      * @throws NestedValidationException Thrown when the assert() fails.
+     * @throws ValidationException
      */
     public function validate()
     {
@@ -51,11 +53,28 @@ class RefundRequest implements \JsonSerializable, RequestInterface
             $items_total = $this->amount;
         }
 
-        v::key('amount', v::notEmpty()->intVal()->equals($items_total))
-        ->assert($props);
+        if (empty($props['amount'])) {
+            throw new ValidationException('Amount can not be empty');
+        }
 
-        // Validate the callback urls.
+        if (!filter_var($props['amount'], FILTER_VALIDATE_INT)) {
+            throw new ValidationException('Amount is not an integer');
+        }
+
+        if ($items_total !== $props['amount']) {
+            throw new ValidationException('ItemsTotal does not match Amount');
+        }
+
+        //v::key('amount', v::notEmpty()->intVal()->equals($items_total))
+        //->assert($props);
+
+        if (empty($props['callbackUrls'])) {
+            throw new ValidationException('CallbackUrls are not set');
+        }
+
         $this->callbackUrls->validate();
+
+        return true;
     }
 
     /**

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use OpMerchantServices\SDK\Client;
+use OpMerchantServices\SDK\Exception\HmacException;
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\Address;
+use OpMerchantServices\SDK\Model\CallbackUrl;
+use OpMerchantServices\SDK\Model\Customer;
+use OpMerchantServices\SDK\Model\Item;
+use OpMerchantServices\SDK\Request\PaymentRequest;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+
+    public function testClient()
+    {
+        $merchantId = 375917;
+        $secret = 'SAIPPUAKAUPPIAS';
+        $args = [
+            'timeout' => 20,
+            'cofPluginVersion' => 'phpunit-test'
+        ];
+
+        $client = new Client($merchantId, $secret, $args);
+
+        $item = (new Item())
+            ->setDeliveryDate('2020-12-12')
+            ->setProductCode('pr1')
+            ->setVatPercentage(24)
+            ->setReference('itemReference123')
+            ->setStamp('itemStamp-' . rand(1, 999999))
+            ->setUnits(1)
+            ->setDescription('some description')
+            ->setUnitPrice(100);
+
+        $item2 = (new Item())
+            ->setDeliveryDate('2020-12-12')
+            ->setProductCode('pr2')
+            ->setVatPercentage(24)
+            ->setReference('itemReference123')
+            ->setStamp('itemStamp-' . rand(1, 999999))
+            ->setUnits(2)
+            ->setDescription('some description2')
+            ->setUnitPrice(200);
+
+        $redirect = (new CallbackUrl())
+            ->setCancel('https://somedomain.com/cancel')
+            ->setSuccess('https://somedomain.com/success');
+
+        $cb = (new CallbackUrl())
+            ->setCancel('https://callbackdomain.com/cancel')
+            ->setSuccess('https://callbackdomain.com/success');
+
+        $customer = (new Customer())
+            ->setEmail('customer@customerdomain.com')
+        ;
+
+        $address = (new Address())
+            ->setStreetAddress('Hämeenkatu 12')
+            ->setCity('Tampere')
+            ->setCountry('Finland')
+            ->setPostalCode('33200')
+        ;
+
+        $paymentRequest = (new PaymentRequest())
+            ->setCustomer($customer)
+            ->setRedirectUrls($redirect)
+            ->setCallbackUrls($cb)
+            ->setItems([$item, $item2])
+            ->setAmount(500)
+            ->setStamp('PaymentRequestStamp' . rand(1, 999999))
+            ->setReference('PaymentRequestReference' . rand(1, 999999))
+            ->setCurrency('EUR')
+            ->setLanguage('EN')
+            ->setDeliveryAddress($address)
+            ->setInvoicingAddress($address)
+        ;
+
+
+        //$providers = $client->getPaymentProviders();
+        //var_dump($providers);
+
+        if ($paymentRequest->validate()) {
+            try {
+                $response = $client->createPayment($paymentRequest);
+
+                $this->assertObjectHasAttribute('transactionId', $response);
+                $this->assertObjectHasAttribute('href', $response);
+                $this->assertObjectHasAttribute('providers', $response);
+                $this->assertIsArray($response->getProviders());
+
+                var_dump($response);
+
+
+            } catch (HmacException $e) {
+                var_dump($e->getMessage());
+            } catch (ValidationException $e) {
+                var_dump($e->getMessage());
+            } catch (\GuzzleHttp\Exception\RequestException $e) {
+                echo 321;
+                var_dump(json_decode($e->getResponse()->getBody()));
+            }
+
+        } else {
+            echo 'PaymentRequest is not valid';
+        }
+
+    }
+
+}

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -17,12 +17,10 @@ class ClientTest extends TestCase
     {
         $merchantId = 375917;
         $secret = 'SAIPPUAKAUPPIAS';
-        $args = [
-            'timeout' => 20,
-            'cofPluginVersion' => 'phpunit-test'
-        ];
+        $args = ['timeout' => 20];
+        $cofPluginVersion = 'phpunit-test';
 
-        $client = new Client($merchantId, $secret, $args);
+        $client = new Client($merchantId, $secret, $cofPluginVersion, $args);
 
         $item = (new Item())
             ->setDeliveryDate('2020-12-12')
@@ -89,16 +87,12 @@ class ClientTest extends TestCase
                 $this->assertObjectHasAttribute('href', $response);
                 $this->assertObjectHasAttribute('providers', $response);
                 $this->assertIsArray($response->getProviders());
-
-                var_dump($response);
-
-
+                //var_dump($response);
             } catch (HmacException $e) {
                 var_dump($e->getMessage());
             } catch (ValidationException $e) {
                 var_dump($e->getMessage());
             } catch (\GuzzleHttp\Exception\RequestException $e) {
-                echo 321;
                 var_dump(json_decode($e->getResponse()->getBody()));
             }
 

--- a/tests/unit/Model/AddressTest.php
+++ b/tests/unit/Model/AddressTest.php
@@ -1,0 +1,84 @@
+<?php
+
+
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\Address;
+use PHPUnit\Framework\TestCase;
+
+class AddressTest extends TestCase
+{
+
+    public function testExceptions()
+    {
+        $this->expectException(ValidationException::class);
+        $a = new Address;
+        $a->validate();
+    }
+
+
+    public function testIsAddressValid()
+    {
+        $a = new Address;
+
+        $this->assertInstanceOf(
+            Address::class,
+            $a
+        );
+
+        $a->setStreetAddress('Downing street')
+            ->setPostalCode('121212')
+            ->setCity('London')
+            ->setCountry('United Kingdom');
+
+        try {
+            $this->assertIsBool($a->validate(), 'Address::validate');
+        } catch (ValidationException $e) {
+        }
+    }
+
+    public function testExeceptionMessages()
+    {
+        $a = new Address;
+
+        try {
+            $a->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('streetAddress is empty', $e->getMessage());
+        }
+
+        $a->setStreetAddress('Piispankatu 2');
+
+        try {
+            $a->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('postalCode is empty', $e->getMessage());
+        }
+
+        $a->setPostalCode('123123');
+
+        try {
+            $a->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('city is empty', $e->getMessage());
+        }
+
+        $a->setCity('Tampere');
+
+        try {
+            $a->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('country is empty', $e->getMessage());
+        }
+
+        $a->setCountry('Finland');
+
+        try {
+            $this->assertIsBool($a->validate(), 'Address::validate is bool');
+        } catch (ValidationException $e) {
+        }
+
+
+
+    }
+
+}

--- a/tests/unit/Model/CallbackUrlTest.php
+++ b/tests/unit/Model/CallbackUrlTest.php
@@ -1,0 +1,62 @@
+<?php
+
+
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\CallbackUrl;
+use PHPUnit\Framework\TestCase;
+
+class CallbackUrlTest extends TestCase
+{
+    public function testExceptions()
+    {
+        $this->expectException(ValidationException::class);
+        $a = new CallbackUrl;
+        $a->validate();
+    }
+
+    public function testIsCallbackUrlValid()
+    {
+        $c = new CallbackUrl;
+
+        $this->assertInstanceOf(CallbackUrl::class, $c);
+
+        $c->setSuccess('https://someurl.com/success')
+            ->setCancel('https://someurl.com/cancel');
+
+        try {
+            $this->assertIsBool($c->validate(), 'CallbackUrl::validate is bool');
+        } catch (ValidationException $e) {
+
+        }
+
+    }
+
+    public function testExceptionMessages()
+    {
+        $c = new CallbackUrl;
+
+        try {
+            $c->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('Success is empty', $e->getMessage());
+        }
+
+        $c->setSuccess('someString');
+
+        try {
+            $c->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('Cancel is empty', $e->getMessage());
+        }
+
+        $c->setCancel('someOtherString');
+
+        try {
+            $this->assertIsBool($c->validate(), 'CallbackUrl::validate is bool');
+        } catch (ValidationException $e) {
+        }
+
+
+    }
+
+}

--- a/tests/unit/Model/CustomerTest.php
+++ b/tests/unit/Model/CustomerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\Customer;
+use PHPUnit\Framework\TestCase;
+
+class CustomerTest extends TestCase
+{
+    public function testEmailValidity()
+    {
+        // Only email is mandatory
+        $c = new Customer();
+        $this->assertInstanceOf(Customer::class, $c);
+        $c->setEmail('asdasdasd@sdaasddas.com');
+        $this->assertIsBool($c->validate(), 'email is valid');
+    }
+
+    public function testExceptions()
+    {
+        // Test fail
+        $this->expectException(ValidationException::class);
+        $c2 = new Customer();
+        $c2->setEmail('notAnEmailAddress');
+        $c2->validate();
+    }
+
+}

--- a/tests/unit/Model/ItemTest.php
+++ b/tests/unit/Model/ItemTest.php
@@ -1,0 +1,87 @@
+<?php
+
+
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\Item;
+use PHPUnit\Framework\TestCase;
+
+class ItemTest extends TestCase
+{
+    public function testIsItemValid()
+    {
+        $i = new Item;
+
+        $this->assertInstanceOf(
+            Item::class,
+            $i
+        );
+
+        $i->setUnitPrice(1)
+            ->setUnits(2)
+            ->setVatPercentage(25)
+            ->setProductCode('productCode123')
+            ->setDeliveryDate('12.12.1999')
+            ->setDescription('description');
+
+        try {
+            $this->assertIsBool($i->validate(), 'Item::validate');
+        } catch (ValidationException $e) {
+        }
+    }
+
+    public function testExceptions()
+    {
+        $this->expectException(ValidationException::class);
+        $i = new Item;
+        $i->validate();
+    }
+
+    public function testExceptionMessages()
+    {
+        $i = new Item;
+
+        try {
+            $i->validate();
+        } catch (Exception $e) {
+            $this->assertStringContainsString('UnitPrice is not an integer', $e->getMessage());
+        }
+
+        try {
+            $i->setUnitPrice(2);
+            $i->validate();
+        } catch (Exception $e) {
+            $this->assertStringContainsString('Units is not an integer', $e->getMessage());
+        }
+
+        try {
+            $i->setUnits(3);
+            $i->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('vatPercentage is not an integer', $e->getMessage());
+        }
+
+        try {
+            $i->setVatPercentage(12);
+            $i->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('productCode is empty', $e->getMessage());
+        }
+
+        try {
+            $i->setProductCode('productCode123');
+            $i->validate();
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('deliveryDate is empty', $e->getMessage());
+        }
+
+        $i->setDeliveryDate('12.12.1999');
+
+        try {
+            $this->assertIsBool($i->validate(), 'Item::validate returns bool');
+        } catch (ValidationException $e) {
+        }
+
+
+    }
+
+}

--- a/tests/unit/Model/RefundItemTest.php
+++ b/tests/unit/Model/RefundItemTest.php
@@ -1,0 +1,34 @@
+<?php
+
+
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\RefundItem;
+use PHPUnit\Framework\TestCase;
+
+class RefundItemTest extends TestCase
+{
+    public function testValidation()
+    {
+        $rfi = new RefundItem();
+        $rfi->setAmount(123.2322323); // setter parameter typecasting should work for floats
+        $this->assertEquals(123, $rfi->getAmount());
+        $rfi->setStamp('someStringValueForTheStamp');
+        $this->assertEquals(true, $rfi->validate());
+    }
+
+    public function testTypeError()
+    {
+        $this->expectException(TypeError::class);
+        $rfi = new RefundItem();
+        $rfi->setAmount("not a number");
+    }
+
+    public function testValidationExceptions()
+    {
+        $this->expectException(ValidationException::class);
+        $rfi = new RefundItem();
+        $rfi->setAmount(123);
+        $rfi->setStamp('');
+        $rfi->validate();
+    }
+}

--- a/tests/unit/Request/EmailRefundRequestTest.php
+++ b/tests/unit/Request/EmailRefundRequestTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use OpMerchantServices\SDK\Model\CallbackUrl;
+use OpMerchantServices\SDK\Model\RefundItem;
+use PHPUnit\Framework\TestCase;
+use OpMerchantServices\SDK\Request\EmailRefundRequest;
+use OpMerchantServices\SDK\Exception\ValidationException;
+
+class EmailRefundRequestTest extends TestCase
+{
+
+    public function testEmailRefundRequest()
+    {
+        $er = new EmailRefundRequest();
+        $er->setAmount(20);
+        $er->setEmail('some@email.com');
+
+        $item = new RefundItem();
+        $item->setAmount(10)
+            ->setStamp('someStamp');
+
+        $item2 = new RefundItem();
+        $item2->setAmount(10)
+            ->setStamp('anotherStamp');
+
+        $er->setItems([$item, $item2]);
+
+        $cb = new CallbackUrl();
+        $cb->setCancel('https://some.url.com/cancel')
+            ->setSuccess('https://some.url.com/success');
+
+        $er->setCallbackUrls($cb);
+
+        $this->assertEquals(true, $er->validate());
+    }
+
+    public function testExceptions()
+    {
+
+        $er = new EmailRefundRequest();
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals("Amount can not be empty", $e->getMessage());
+        }
+
+        $er->setAmount(99999);
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('CallbackUrls are not set', $e->getMessage());
+        }
+
+        $cb = new CallbackUrl();
+        $er->setCallbackUrls($cb);
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('Success is empty', $e->getMessage());
+        }
+
+        $cb->setSuccess('someurl.somewhere.com/success');
+        $er->setCallbackUrls($cb);
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('Cancel is empty', $e->getMessage());
+        }
+
+        $cb->setCancel('someurl.somewhere.com/cancel');
+        $er->setCallbackUrls($cb);
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('Success is not a valid URL', $e->getMessage());
+        }
+
+        $cb->setSuccess('https://someurl.somewhere.com/success');
+        $er->setCallbackUrls($cb);
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('Cancel is not a valid URL', $e->getMessage());
+        }
+
+        $cb->setCancel('https://someurl.somewhere.com/cancel');
+        $er->setCallbackUrls($cb);
+
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('email can not be empty', $e->getMessage());
+        }
+
+        $er->setEmail('some@email.com');
+
+        // Items are not mandatory, so should pass from here
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            var_dump($e->getMessage());
+        }
+
+        $item = new RefundItem();
+        $item->setAmount(110)
+            ->setStamp('someStamp');
+
+        $item2 = new RefundItem();
+        $item2->setAmount(10)
+            ->setStamp('anotherStamp');
+
+        $er->setItems([$item, $item2]);
+
+        // Fails, as refund->total was set to 9999
+        try {
+            $er->validate();
+        } catch (ValidationException $e) {
+            $this->assertEquals('ItemsTotal does not match Amount', $e->getMessage());
+        }
+
+        // Set correct amount
+        $er->setAmount(120);
+
+        try {
+            $this->assertEquals(true, $er->validate());
+        } catch (ValidationException $e) {
+        }
+    }
+}

--- a/tests/unit/Request/PaymentRequestTest.php
+++ b/tests/unit/Request/PaymentRequestTest.php
@@ -58,11 +58,4 @@ class PaymentRequestTest extends TestCase
         } catch (ValidationException $e) {
         }
     }
-
-    public function testExceptions()
-    {
-
-    }
-
-
 }

--- a/tests/unit/Request/PaymentRequestTest.php
+++ b/tests/unit/Request/PaymentRequestTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use OpMerchantServices\SDK\Exception\ValidationException;
+use OpMerchantServices\SDK\Model\CallbackUrl;
+use OpMerchantServices\SDK\Model\Customer;
+use OpMerchantServices\SDK\Model\Item;
+use OpMerchantServices\SDK\Request\PaymentRequest;
+use PHPUnit\Framework\TestCase;
+
+class PaymentRequestTest extends TestCase
+{
+    public function testPaymentRequest()
+    {
+        $r = new PaymentRequest();
+        $r->setAmount(30);
+        $r->setStamp('RequestStamp');
+        $r->setReference('RequestReference123');
+        $r->setCurrency('EUR');
+        $r->setLanguage('EN');
+
+        $item1 = new Item();
+        $item1->setStamp('someStamp')
+            ->setDeliveryDate('12.12.2020')
+            ->setProductCode('pr1')
+            ->setVatPercentage(25)
+            ->setUnitPrice(10)
+            ->setUnits(1);
+
+        $item2 = new Item();
+        $item2->setStamp('someOtherStamp')
+            ->setDeliveryDate('12.12.2020')
+            ->setProductCode('pr2')
+            ->setVatPercentage(25)
+            ->setUnitPrice(10)
+            ->setUnits(2);
+
+        $r->setItems([$item1, $item2]);
+
+        $c = new Customer();
+        $c->setEmail('customer@email.com');
+
+        $r->setCustomer($c);
+
+        $cb = new CallbackUrl();
+        $cb->setCancel('https://somedomain.com/cancel')
+            ->setSuccess('https://somedomain.com/success');
+
+        $r->setCallbackUrls($cb);
+
+        $redirect = new CallbackUrl();
+        $redirect->setSuccess('https://someother.com/success')
+            ->setCancel('https://someother.com/cancel');
+
+        $r->setRedirectUrls($redirect);
+
+        try {
+            $this->assertEquals(true, $r->validate());
+        } catch (ValidationException $e) {
+        }
+    }
+
+    public function testExceptions()
+    {
+
+    }
+
+
+}


### PR DESCRIPTION
- Remove the current validation library as it causes some problems with hosting providers that don't have MBString enabled. Validations performed now with filter_var() and empty() 
- Added cofPluginVersion parameter to Client constructor to prevent the use of the fallback value, which skews stats and makes support a bit troublesome
- Added PHPUnit testsuite and tests